### PR TITLE
Use standard type annotations.

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -1,4 +1,5 @@
 from enum import auto, Enum
+from typing import Any
 
 
 class ActionType(Enum):
@@ -7,6 +8,6 @@ class ActionType(Enum):
 
 
 class Action:
-    def __init__(self, action_type: ActionType, **kwargs):
-        self.action_type: ActionType = action_type
+    def __init__(self, action_type: ActionType, **kwargs: Any):
+        self.action_type = action_type
         self.kwargs = kwargs

--- a/input_handlers.py
+++ b/input_handlers.py
@@ -1,10 +1,12 @@
+from typing import Optional
+
 import tcod.event
 
 from actions import Action, ActionType
 
 
-def handle_keys(key) -> [Action, None]:
-    action: [Action, None] = None
+def handle_keys(key: int) -> Optional[Action]:
+    action: Optional[Action] = None
 
     if key == tcod.event.K_UP:
         action = Action(ActionType.MOVEMENT, dx=0, dy=-1)

--- a/main.py
+++ b/main.py
@@ -4,12 +4,12 @@ from actions import Action, ActionType
 from input_handlers import handle_keys
 
 
-def main():
-    screen_width: int = 80
-    screen_height: int = 50
+def main() -> None:
+    screen_width = 80
+    screen_height = 50
 
-    player_x: int = int(screen_width / 2)
-    player_y: int = int(screen_height / 2)
+    player_x = int(screen_width / 2)
+    player_y = int(screen_height / 2)
 
     tcod.console_set_custom_font("arial10x10.png", tcod.FONT_TYPE_GREYSCALE | tcod.FONT_LAYOUT_TCOD)
 
@@ -32,7 +32,7 @@ def main():
                     raise SystemExit()
 
                 if event.type == "KEYDOWN":
-                    action: [Action, None] = handle_keys(event.sym)
+                    action = handle_keys(event.sym)
 
                     if action is None:
                         continue


### PR DESCRIPTION
```
mypy . --strict
actions.py:10: error: Function is missing a type annotation for one or more arguments
input_handlers.py:6: error: Bracketed expression "[...]" is not valid as a type
input_handlers.py:6: note: Did you mean "List[...]"?
input_handlers.py:6: error: Function is missing a type annotation for one or more arguments
input_handlers.py:7: error: Bracketed expression "[...]" is not valid as a type
input_handlers.py:7: note: Did you mean "List[...]"?
main.py:7: error: Function is missing a return type annotation
main.py:7: note: Use "-> None" if function does not return a value
main.py:35: error: Bracketed expression "[...]" is not valid as a type
main.py:35: note: Did you mean "List[...]"?
main.py:53: error: Call to untyped function "main" in typed context
Found 7 errors in 3 files (checked 3 source files)
```
All issues are fixed:
```
mypy . --strict
Success: no issues found in 3 source files
```
I've removed some redundant hints.  These variables are correctly typed without a hint.  To get used to type hinting you should run `mypy` with the `--strict` argument and add hints wherever it complains.  The `dx`,`dy` hints were important to keep, since `action.kwargs` is `Dict[str, Any]`.

Also keep in mind that tcod events are not typed unless tcod.event.EventDispatch is used, but I might talk about that later.

This is ready to be merged.