### PR TITLE
Switch to using tcod contexts.

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,19 +11,22 @@ def main():
     player_x: int = int(screen_width / 2)
     player_y: int = int(screen_height / 2)
 
-    tcod.console_set_custom_font("arial10x10.png", tcod.FONT_TYPE_GREYSCALE | tcod.FONT_LAYOUT_TCOD)
+    tileset = tcod.tileset.load_tilesheet(
+        "arial10x10.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+    )
 
-    with tcod.console_init_root(
-            w=screen_width,
-            h=screen_height,
-            title="Yet Another Roguelike Tutorial",
-            order="F",
-            vsync=True
-    ) as root_console:
+    with tcod.context.new_terminal(
+        screen_width,
+        screen_height,
+        tileset=tileset,
+        title="Yet Another Roguelike Tutorial",
+        vsync=True,
+    ) as context:
+        root_console = tcod.Console(screen_width, screen_height, order="F")
         while True:
             root_console.print(x=player_x, y=player_y, string="@")
 
-            tcod.console_flush()
+            context.present(root_console)
 
             root_console.clear()
 


### PR DESCRIPTION
Normally I'd use [tcod.context.new_window](https://python-tcod.readthedocs.io/en/latest/tcod/context.html#tcod.context.new_window) and derive the console size dynamically, but since the tutorial starts with a fixed size console I used [tcod.context.new_terminal](https://python-tcod.readthedocs.io/en/latest/tcod/context.html#tcod.context.new_terminal) and made a console of the same size.  `tcod.console_flush` is replaced by [Context.present](https://python-tcod.readthedocs.io/en/latest/tcod/context.html#tcod.context.Context.present) but I don't think any other changes need to be made.  These might be a little bit harder to work with since they're no longer global objects, but you can always store them globally.

Because the console has been completely decoupled from libtcod's global context you can now do things like switch to a console of a different size in response to a window resized event.  There's a good [helper method](https://python-tcod.readthedocs.io/en/latest/tcod/context.html#tcod.context.Context.recommended_console_size) for that.

The long term plan was to remove functions which work on hidden global objects such as `tcod.console_init_root` and `tcod.console_set_custom_font` which is why I've made a big deal about this.

This is ready to be merged.