### PR TITLE
Mark main.py as a Python 3 executable.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import tcod
 
 from actions import Action, ActionType


### PR DESCRIPTION
Added the Python 3 shebang and applied `chmod +x` so that the file is executable on Unix systems.

On MacOS/Linux you can run the script with `./main.py` which is the standard way to run these kind of things from the console on those systems.  This also helps the Windows Python Launcher determine which version of Python to use.