### PR TITLE
Convert Action into a polymorphic class.

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -1,14 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from engine import Engine
+    from entity import Entity
+
+
 class Action:
-    pass
+    def perform(self, engine: Engine, entity: Entity) -> None:
+        """Perform this action with the objects needed to determine its scope.
+
+        `engine` is the scope this action is being performed in.
+
+        `entity` is the object performing the action.
+
+        This method must be overridden by Action subclasses.
+        """
+        raise NotImplementedError()
 
 
 class EscapeAction(Action):
-    pass
+    def perform(self, engine: Engine, entity: Entity) -> None:
+        raise SystemExit()
 
 
 class MovementAction(Action):
     def __init__(self, dx: int, dy: int):
         super().__init__()
-
         self.dx = dx
         self.dy = dy
+
+    def perform(self, engine: Engine, entity: Entity) -> None:
+        dest_x = entity.x + self.dx
+        dest_y = entity.y + self.dy
+
+        if not engine.game_map.in_bounds(dest_x, dest_y):
+            return  # Destination is out of bounds.
+        if not engine.game_map.tiles["walkable"][dest_x, dest_y]:
+            return  # Destination is blocked by a tile.
+
+        entity.x = dest_x
+        entity.y = dest_y

--- a/engine.py
+++ b/engine.py
@@ -23,12 +23,7 @@ class Engine:
             if action is None:
                 continue
 
-            if isinstance(action, MovementAction):
-                if self.game_map.tiles["walkable"][self.player.x + action.dx, self.player.y + action.dy]:
-                    self.player.move(dx=action.dx, dy=action.dy)
-
-            elif isinstance(action, EscapeAction):
-                raise SystemExit()
+            action.perform(self, self.player)
 
     def render(self, console: Console, context: Context) -> None:
         self.game_map.render(console)

--- a/entity.py
+++ b/entity.py
@@ -13,10 +13,5 @@ class Entity:
         self.char = char
         self.color = color
 
-    def move(self, dx: int, dy: int) -> None:
-        # Move the entity by a given amount
-        self.x += dx
-        self.y += dy
-
     def render(self, console: Console):
         console.print(x=self.x, y=self.y, string=self.char, fg=self.color)

--- a/game_map.py
+++ b/game_map.py
@@ -11,5 +11,9 @@ class GameMap:
 
         self.tiles[30:33, 22] = tile_types.wall
 
+    def in_bounds(self, x: int, y: int) -> bool:
+        """Return True if x and y are inside of the bounds of this map."""
+        return 0 <= x < self.width and 0 <= y < self.height
+
     def render(self, console: Console) -> None:
         console.tiles_rgb[0:self.width, 0:self.height] = self.tiles["dark"]


### PR DESCRIPTION
I had trouble with `Entity.move` since it didn't have enough context to handle blocked paths.  What functionality it did have wasn't better than just assigning to the positions directly.

I refactored the growing `if..elif` chain into a single method:  `Action.perform`, which takes the engine and entity.  Action subclasses can now handle anything you were going to put in the `Engine.handle_events` method and can already work with non-player entities.

Once I did that I added bounds checking so that entities can't try to move outside of the map anymore.

There are lots of ways things can go from here but it's probably best to try and leave it simple.  Keep in mind that Actions can create and perform new actions while their own action is being performed, so this can be used for simple AI.

Here's the first instance of `from __future__ import annotations` and `TYPE_CHECKING`.  These will come up more often if you want to have everything fully typed.

`TYPE_CHECKING` lets you import modules for type hinting without importing them for real.  This is to prevent cyclic imports, especially with the engine module.

Since the modules aren't imported, using them for annotations will crash at run-time unless you wrap them all in strings.  `from __future__ import annotations` does this for you and will be the default behavior in Python 4.x.

So whenever `TYPE_CHECKING` is used you should add `from __future__ import annotations`, and you use `TYPE_CHECKING` to prevent cyclic imports.