### PR TITLE
Replace entity list with an entity set.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1,4 +1,4 @@
-from typing import List, Iterable, Any
+from typing import Set, Iterable, Any
 
 from tcod.context import Context
 from tcod.console import Console
@@ -10,7 +10,7 @@ from input_handlers import EventHandler
 
 
 class Engine:
-    def __init__(self, entities: List[Entity], event_handler: EventHandler, game_map: GameMap, player: Entity):
+    def __init__(self, entities: Set[Entity], event_handler: EventHandler, game_map: GameMap, player: Entity):
         self.entities = entities
         self.event_handler = event_handler
         self.game_map = game_map

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def main() -> None:
 
     player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
     npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))
-    entities = [npc, player]
+    entities = {npc, player}
 
     game_map = GameMap(map_width, map_height)
 


### PR DESCRIPTION
Sets can do a few things faster than lists and are good for randomly inserting and removing objects.

The _real_ reason to use a set is because modifying a set during iteration is an error which will avoid a lot of debugging you'd have to do if you accidentally modified a list during iteration.