### PR TITLE
Split dungeon generation into a new module.

### DIFF
--- a/game_map.py
+++ b/game_map.py
@@ -1,107 +1,13 @@
-from __future__ import annotations
-
-from random import randint
-from typing import List, Tuple, TYPE_CHECKING
-
 import numpy as np  # type: ignore
 from tcod.console import Console
 
 import tile_types
-
-if TYPE_CHECKING:
-    from entity import Entity
-
-
-class Rect:
-    def __init__(self, x: int, y: int, width: int, height: int):
-        self.x1 = x
-        self.y1 = y
-        self.x2 = x + width
-        self.y2 = y + height
-
-    @property
-    def center(self) -> Tuple[int, int]:
-        center_x = int((self.x1 + self.x2) / 2)
-        center_y = int((self.y1 + self.y2) / 2)
-
-        return center_x, center_y
-
-    def intersects(self, other: Rect) -> bool:
-        return self.x1 <= other.x2 and self.x2 >= other.x1 and self.y1 <= other.y2 and self.y2 >= other.y1
 
 
 class GameMap:
     def __init__(self, width: int, height: int):
         self.width, self.height = width, height
         self.tiles = np.full((width, height), fill_value=tile_types.wall, order="F")
-
-    def create_horizontal_tunnel(self, x1: int, x2: int, y: int) -> None:
-        min_x = min(x1, x2)
-        max_x = max(x1, x2) + 1
-
-        self.tiles[min_x:max_x, y] = tile_types.floor
-
-    def create_room(self, room: Rect) -> None:
-        self.tiles[room.x1+1:room.x2, room.y1+1:room.y2] = tile_types.floor
-
-    def create_vertical_tunnel(self, y1: int, y2: int, x: int) -> None:
-        min_y = min(y1, y2)
-        max_y = max(y1, y2) + 1
-
-        self.tiles[x, min_y:max_y] = tile_types.floor
-
-    def make_map(self, max_rooms: int, room_min_size: int, room_max_size: int, map_width: int, map_height: int,
-                 player: Entity) -> None:
-        rooms: List[Rect] = []
-        number_of_rooms = 0
-
-        for r in range(max_rooms):
-            width = randint(room_min_size, room_max_size)
-            height = randint(room_min_size, room_max_size)
-
-            x = randint(0, map_width - width - 1)
-            y = randint(0, map_height - height - 1)
-
-            # "Rect" class makes rectangles easier to work with
-            new_room = Rect(x, y, width, height)
-
-            # run through the other rooms and see if they intersect with this one
-            for other_room in rooms:
-                if new_room.intersects(other_room):
-                    break
-            else:
-                # this means there are no intersections, so this room is valid
-
-                # "paint" it to the map's tiles
-                self.create_room(new_room)
-
-                # center coordinates of new room, will be useful later
-                (new_x, new_y) = new_room.center
-
-                if number_of_rooms == 0:
-                    # this is the first room, where the player starts at
-                    player.x = new_x
-                    player.y = new_y
-                else:
-                    # all rooms after the first:
-                    # connect it to the previous room with a tunnel
-
-                    # center coordinates of previous room
-                    (prev_x, prev_y) = rooms[number_of_rooms - 1].center
-
-                    # flip a coin (random number that is either 0 or 1)
-                    if randint(0, 1) == 1:
-                        # first move horizontally, then vertically
-                        self.create_horizontal_tunnel(prev_x, new_x, prev_y)
-                        self.create_vertical_tunnel(prev_y, new_y, new_x)
-                    else:
-                        # first move vertically, then horizontally
-                        self.create_vertical_tunnel(prev_y, new_y, prev_x)
-                        self.create_horizontal_tunnel(prev_x, new_x, new_y)
-
-                # finally, append the new room to the list
-                rooms.append(new_room)
-                number_of_rooms += 1
 
     def in_bounds(self, x: int, y: int) -> bool:
         """Return True if x and y are inside of the bounds of this map."""

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from engine import Engine
 from entity import Entity
 from game_map import GameMap
 from input_handlers import EventHandler
+import procgen
 
 
 def main() -> None:
@@ -28,8 +29,7 @@ def main() -> None:
     npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))
     entities = {npc, player}
 
-    game_map = GameMap(map_width, map_height)
-    game_map.make_map(
+    game_map = procgen.generate_dungeon(
         max_rooms=max_rooms,
         room_min_size=room_min_size,
         room_max_size=room_max_size,

--- a/procgen.py
+++ b/procgen.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from random import randint
+from typing import List, Tuple, TYPE_CHECKING
+
+import numpy as np  # type: ignore
+
+from game_map import GameMap
+import tile_types
+
+
+if TYPE_CHECKING:
+    from entity import Entity
+
+
+class Rect:
+    def __init__(self, x: int, y: int, width: int, height: int):
+        self.x1 = x
+        self.y1 = y
+        self.x2 = x + width
+        self.y2 = y + height
+
+    @property
+    def center(self) -> Tuple[int, int]:
+        center_x = int((self.x1 + self.x2) / 2)
+        center_y = int((self.y1 + self.y2) / 2)
+
+        return center_x, center_y
+
+    @property
+    def inner(self) -> Tuple[slice, slice]:
+        """Return the inner area of this room as a 2D array index."""
+        return slice(self.x1 + 1, self.x2), slice(self.y1 + 1, self.y2)
+
+    def intersects(self, other: Rect) -> bool:
+        """Return True if this Rect overlaps with another Rect."""
+        return (
+            self.x1 <= other.x2
+            and self.x2 >= other.x1
+            and self.y1 <= other.y2
+            and self.y2 >= other.y1
+        )
+
+
+def create_horizontal_tunnel(gamemap: GameMap, x1: int, x2: int, y: int) -> None:
+    min_x = min(x1, x2)
+    max_x = max(x1, x2) + 1
+
+    gamemap.tiles[min_x:max_x, y] = tile_types.floor
+
+
+def create_vertical_tunnel(gamemap: GameMap, y1: int, y2: int, x: int) -> None:
+    min_y = min(y1, y2)
+    max_y = max(y1, y2) + 1
+
+    gamemap.tiles[x, min_y:max_y] = tile_types.floor
+
+
+def generate_dungeon(
+    max_rooms: int,
+    room_min_size: int,
+    room_max_size: int,
+    map_width: int,
+    map_height: int,
+    player: Entity,
+) -> GameMap:
+    """Generate a new dungeon map."""
+    dungeon = GameMap(map_width, map_height)
+
+    rooms: List[Rect] = []
+
+    for r in range(max_rooms):
+        width = randint(room_min_size, room_max_size)
+        height = randint(room_min_size, room_max_size)
+
+        x = randint(0, dungeon.width - width - 1)
+        y = randint(0, dungeon.height - height - 1)
+
+        # "Rect" class makes rectangles easier to work with
+        new_room = Rect(x, y, width, height)
+
+        # run through the other rooms and see if they intersect with this one
+        if any(new_room.intersects(other_room) for other_room in rooms):
+            continue  # this room intersects, so go to the next attempt
+        # if there are no intersections then the room is valid
+
+        # dig out the rooms inner area
+        dungeon.tiles[new_room.inner] = tile_types.floor
+
+        # center coordinates of new room, will be useful later
+        (new_x, new_y) = new_room.center
+
+        if len(rooms) == 0:
+            # this is the first room, where the player starts at
+            player.x = new_x
+            player.y = new_y
+        else:
+            # all rooms after the first:
+            # connect it to the previous room with a tunnel
+
+            # center coordinates of previous room
+            (prev_x, prev_y) = rooms[-1].center
+
+            # flip a coin (random number that is either 0 or 1)
+            if randint(0, 1) == 1:
+                # first move horizontally, then vertically
+                create_horizontal_tunnel(dungeon, prev_x, new_x, prev_y)
+                create_vertical_tunnel(dungeon, prev_y, new_y, new_x)
+            else:
+                # first move vertically, then horizontally
+                create_vertical_tunnel(dungeon, prev_y, new_y, prev_x)
+                create_horizontal_tunnel(dungeon, prev_x, new_x, new_y)
+
+        # finally, append the new room to the list
+        rooms.append(new_room)
+
+    return dungeon


### PR DESCRIPTION
This code was putting a lot of responsibilities on GameMap so I moved everything to a new module: `procgen.py`

The `GameMap.make_map` took the size of the map but the `GameMap` was already given a size at its creation.  This has caused grief for anyone who only changed one of those parameters and couldn't figure out why they were getting IndexError's.  This has all been replaced by a factory function which creates returns a new `GameMap`, and `GameMap`'s `width` and `height` are used whenever possible.

The `number_of_rooms` variable was redundant, so I changed anything using it to `len(rooms)`.

I added a `Rect.inner` property which can be used to index the tiles array.  The result is a little less hard-coded than `create_room`.

Checking for room intersections was converted into a generator expression and the rest of the function was flattened.  Almost anything is better than the `for...else` clause used here, it's really easy for people to misunderstand it.

I'll be using this as a base for more pull requests.