### PR TITLE
Simplified FOV.

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -43,4 +43,6 @@ class MovementAction(Action):
 
         entity.move(self.dx, self.dy)
 
-        engine.fov_recompute = True
+        # If the player just moved then the field of view needs updating.
+        if entity is engine.player:
+            engine.update_fov()

--- a/actions.py
+++ b/actions.py
@@ -42,7 +42,3 @@ class MovementAction(Action):
             return  # Destination is blocked by a tile.
 
         entity.move(self.dx, self.dy)
-
-        # If the player just moved then the field of view needs updating.
-        if entity is engine.player:
-            engine.update_fov()

--- a/engine.py
+++ b/engine.py
@@ -13,10 +13,9 @@ class Engine:
     def __init__(self, entities: Set[Entity], event_handler: EventHandler, game_map: GameMap, player: Entity):
         self.entities = entities
         self.event_handler = event_handler
-        self.fov_recompute = True
-        self.fov_map = compute_fov(game_map.tiles["transparent"], (player.x, player.y), radius=8)
         self.game_map = game_map
         self.player = player
+        self.update_fov()
 
     def handle_events(self, events: Iterable[Any]) -> None:
         for event in events:
@@ -27,25 +26,28 @@ class Engine:
 
             action.perform(self, self.player)
 
+    def update_fov(self) -> None:
+        """Recompute the visible area based on the players point of view.
+
+        Call this after any of the following:
+        * The player has moved to a different position or a different map.
+        * Tile transparency has been altered on the current map.
+        """
+        self.game_map.visible[:] = compute_fov(
+            self.game_map.tiles["transparent"],
+            (self.player.x, self.player.y),
+            radius=8,
+        )
+        # If a tile is "visible" it should be added to "explored".
+        self.game_map.explored |= self.game_map.visible
+
     def render(self, console: Console, context: Context) -> None:
-        if self.fov_recompute:
-            # Get the new FOV map based on the Player's current position
-            self.fov_map = compute_fov(self.game_map.tiles["transparent"], (self.player.x, self.player.y), radius=8)
-
-            # Set the "visible" tiles in the map to whatever is in the FOV map
-            self.game_map.visible = self.fov_map
-
-            # If a tile is in "visible", it should also be in "explored"
-            self.game_map.explored |= self.game_map.visible
-
-            self.fov_recompute = False
-
         self.game_map.render(console)
 
         for entity in self.entities:
-            # Only render entities that are in the FOV
-            if self.fov_map[entity.x, entity.y]:
-                console.print(entity.x, entity.y, entity.char, fg=entity.color)
+            if not self.game_map.visible[entity.x, entity.y]:
+                continue  # Skip entities not in the FOV.
+            console.print(entity.x, entity.y, entity.char, fg=entity.color)
 
         context.present(console)
 

--- a/engine.py
+++ b/engine.py
@@ -26,13 +26,10 @@ class Engine:
 
             action.perform(self, self.player)
 
-    def update_fov(self) -> None:
-        """Recompute the visible area based on the players point of view.
+            self.update_fov()  # Update the FOV before the players next action.
 
-        Call this after any of the following:
-        * The player has moved to a different position or a different map.
-        * Tile transparency has been altered on the current map.
-        """
+    def update_fov(self) -> None:
+        """Recompute the visible area based on the players point of view."""
         self.game_map.visible[:] = compute_fov(
             self.game_map.tiles["transparent"],
             (self.player.x, self.player.y),


### PR DESCRIPTION
With this version you have a `update_fov` function you call directly.

I had a version that only updated FOV when the player moves, but I simplified that even more to call it after every player action.  That was the only way to ensure that it could never glitch out in future code for all kinds of possible reasons.  Later on this call should be moved to after the end of the enemies turn when control returns to the player.