### PR TITLE
Refactor usage of the entities variable.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1,4 +1,4 @@
-from typing import Set, Iterable, Any
+from typing import Iterable, Any
 
 from tcod.context import Context
 from tcod.console import Console
@@ -10,8 +10,7 @@ from input_handlers import EventHandler
 
 
 class Engine:
-    def __init__(self, entities: Set[Entity], event_handler: EventHandler, game_map: GameMap, player: Entity):
-        self.entities = entities
+    def __init__(self, event_handler: EventHandler, game_map: GameMap, player: Entity):
         self.event_handler = event_handler
         self.game_map = game_map
         self.player = player

--- a/game_map.py
+++ b/game_map.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set
+from typing import Iterable, Optional
 
 import numpy as np  # type: ignore
 from tcod.console import Console
@@ -8,9 +8,9 @@ import tile_types
 
 
 class GameMap:
-    def __init__(self, width: int, height: int, entities: Set[Entity]):
+    def __init__(self, width: int, height: int, entities: Iterable[Entity] = ()):
         self.width, self.height = width, height
-        self.entities = entities
+        self.entities = set(entities)
         self.tiles = np.full((width, height), fill_value=tile_types.wall, order="F")
 
         self.visible = np.full((width, height), fill_value=False, order="F")  # Tiles the player can currently see

--- a/main.py
+++ b/main.py
@@ -27,7 +27,6 @@ def main() -> None:
     event_handler = EventHandler()
 
     player = create_player(0, 0)
-    entities = {player}
 
     game_map = generate_dungeon(
         max_rooms=max_rooms,
@@ -37,10 +36,9 @@ def main() -> None:
         map_height=map_height,
         max_monsters_per_room=max_monsters_per_room,
         player=player,
-        entities=entities
     )
 
-    engine = Engine(entities=entities, event_handler=event_handler, game_map=game_map, player=player)
+    engine = Engine(event_handler=event_handler, game_map=game_map, player=player)
 
     with tcod.context.new_terminal(
         screen_width,

--- a/procgen.py
+++ b/procgen.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import random
-from typing import Iterator, List, Set, Tuple, TYPE_CHECKING
+from typing import Iterator, List, Tuple, TYPE_CHECKING
 
 import tcod
 
@@ -43,20 +43,22 @@ class RectangularRoom:
         )
 
 
-def place_entities(room: RectangularRoom, entities: Set[Entity], maximum_monsters: int) -> None:
+def place_entities(
+    room: RectangularRoom, dungeon: GameMap, maximum_monsters: int,
+) -> None:
     number_of_monsters = random.randint(0, maximum_monsters)
 
     for i in range(number_of_monsters):
         x = random.randint(room.x1 + 1, room.x2 - 1)
         y = random.randint(room.y1 + 1, room.y2 - 1)
 
-        if not any([entity for entity in entities if entity.x == x and entity.y == y]):
+        if not any(entity.x == x and entity.y == y for entity in dungeon.entities):
             if random.random() < 0.8:
                 monster = create_orc(x, y)
             else:
                 monster = create_troll(x, y)
 
-            entities.add(monster)
+            dungeon.entities.add(monster)
 
 
 def tunnel_between(
@@ -87,10 +89,9 @@ def generate_dungeon(
     map_height: int,
     max_monsters_per_room: int,
     player: Entity,
-    entities: Set[Entity],
 ) -> GameMap:
     """Generate a new dungeon map."""
-    dungeon = GameMap(map_width, map_height, entities)
+    dungeon = GameMap(map_width, map_height, entities=[player])
 
     rooms: List[RectangularRoom] = []
 
@@ -112,7 +113,7 @@ def generate_dungeon(
         # Dig out this rooms inner area.
         dungeon.tiles[new_room.inner] = tile_types.floor
 
-        place_entities(new_room, entities, max_monsters_per_room)
+        place_entities(new_room, dungeon, max_monsters_per_room)
 
         if len(rooms) == 0:
             # The first room, where the player starts.

--- a/procgen.py
+++ b/procgen.py
@@ -113,8 +113,6 @@ def generate_dungeon(
         # Dig out this rooms inner area.
         dungeon.tiles[new_room.inner] = tile_types.floor
 
-        place_entities(new_room, dungeon, max_monsters_per_room)
-
         if len(rooms) == 0:
             # The first room, where the player starts.
             player.x, player.y = new_room.center
@@ -122,6 +120,8 @@ def generate_dungeon(
             # Dig out a tunnel between this room and the previous one.
             for x, y in tunnel_between(rooms[-1].center, new_room.center):
                 dungeon.tiles[x, y] = tile_types.floor
+
+        place_entities(new_room, dungeon, max_monsters_per_room)
 
         # Finally, append the new room to the list.
         rooms.append(new_room)


### PR DESCRIPTION
GameMap now takes an iterable to convert into an entities set instead of using the input directly.  It's more useful for the inputs of a function to be broad type and the output to be a specific type, and GameMap should own it's copy of entities rather than sharing it.

Removed `entities` from `Engine`, `main.py`, and as a parameter to `generate_dungeon`.  `generate_dungeon` will handle all entities on a dungeon level so there's no need to prepare any beforehand.  `player` is a special case, but even that won't be needed as a parameter to `generate_dungeon` after stairs are created.

Change parameter which takes entities directly to take GameMap instead.  This more of a preemptive refactor, functions adding things to the GameMap should take the entire type in case they're extended to do anything else.  A similar reason to functions taking the Engine type.

This list comprehension here:
```python
if not any([entity for entity in entities if entity.x == x and entity.y == y]):
```
Is equivalent to:
```python
if not [True for entity in entities if entity.x == x and entity.y == y]:
```
It does work, but the reason to do this generator expression:
```python
if not any(entity.x == x and entity.y == y for entity in dungeon.entities):
```
Is to short-circuit the loop on the first True value.  For that it has to be a generator expression and not a list comprehension.  When you use `if` in a generator or comprehension it's to filter the iterator so that only a subset is returned, but `any` is expected to test most of the results of a generator.