### PR TITLE
Handle enemy turns after any action is performed.

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -45,8 +45,6 @@ class MeleeAction(ActionWithDirection):
     def perform(self, engine: Engine, entity: Entity) -> None:
         print(f"You kick the {self.target.name}, much to its annoyance!")
 
-        engine.handle_enemy_turns()
-
 
 class MovementAction(ActionWithDirection):
     def perform(self, engine: Engine, entity: Entity) -> None:
@@ -59,8 +57,6 @@ class MovementAction(ActionWithDirection):
             return  # Destination is blocked by a tile.
 
         entity.move(self.dx, self.dy)
-
-        engine.handle_enemy_turns()
 
 
 class BumpAction(ActionWithDirection):

--- a/engine.py
+++ b/engine.py
@@ -29,7 +29,7 @@ class Engine:
                 continue
 
             action.perform(self, self.player)
-
+            self.handle_enemy_turns()
             self.update_fov()  # Update the FOV before the players next action.
 
     def update_fov(self) -> None:


### PR DESCRIPTION
Enemies will eventually use actions themselves, so putting a `handle_enemy_turns` call inside of an action is a bad idea.

If you want to make it so that the enemy turn only triggers on a 'valid' action then it would be a good time to define the return type of `Action.perform` to provide that kind of information.  Returning the results of chained actions is specifically meant to allow this.