### PR TITLE
Refactor movement keys.

### DIFF
--- a/input_handlers.py
+++ b/input_handlers.py
@@ -10,6 +10,43 @@ if TYPE_CHECKING:
     from engine import Engine
 
 
+MOVE_KEYS = {
+    # Arrow keys.
+    tcod.event.K_UP: (0, -1),
+    tcod.event.K_DOWN: (0, 1),
+    tcod.event.K_LEFT: (-1, 0),
+    tcod.event.K_RIGHT: (1, 0),
+    tcod.event.K_HOME: (-1, -1),
+    tcod.event.K_END: (-1, 1),
+    tcod.event.K_PAGEUP: (1, -1),
+    tcod.event.K_PAGEDOWN: (1, 1),
+    # Numpad keys.
+    tcod.event.K_KP_1: (-1, 1),
+    tcod.event.K_KP_2: (0, 1),
+    tcod.event.K_KP_3: (1, 1),
+    tcod.event.K_KP_4: (-1, 0),
+    tcod.event.K_KP_6: (1, 0),
+    tcod.event.K_KP_7: (-1, -1),
+    tcod.event.K_KP_8: (0, -1),
+    tcod.event.K_KP_9: (1, -1),
+    # Vi keys.
+    tcod.event.K_h: (-1, 0),
+    tcod.event.K_j: (0, 1),
+    tcod.event.K_k: (0, -1),
+    tcod.event.K_l: (1, 0),
+    tcod.event.K_y: (-1, -1),
+    tcod.event.K_u: (1, -1),
+    tcod.event.K_b: (-1, 1),
+    tcod.event.K_n: (1, 1),
+}
+
+WAIT_KEYS = {
+    tcod.event.K_PERIOD,
+    tcod.event.K_KP_5,
+    tcod.event.K_CLEAR,
+}
+
+
 class EventHandler(tcod.event.EventDispatch[Action]):
     def __init__(self, engine: Engine):
         self.engine = engine
@@ -46,23 +83,10 @@ class MainGameEventHandler(EventHandler):
         # Common arguments for player actions.
         context = (self.engine, self.engine.player)
 
-        if key in (tcod.event.K_UP, tcod.event.K_k):
-            action = BumpAction(*context, dx=0, dy=-1)
-        elif key in (tcod.event.K_DOWN, tcod.event.K_j):
-            action = BumpAction(*context, dx=0, dy=1)
-        elif key in (tcod.event.K_LEFT, tcod.event.K_h):
-            action = BumpAction(*context, dx=-1, dy=0)
-        elif key in (tcod.event.K_RIGHT, tcod.event.K_l):
-            action = BumpAction(*context, dx=1, dy=0)
-        elif key == tcod.event.K_y:
-            action = BumpAction(*context, dx=-1, dy=-1)
-        elif key == tcod.event.K_u:
-            action = BumpAction(*context, dx=1, dy=-1)
-        elif key == tcod.event.K_b:
-            action = BumpAction(*context, dx=-1, dy=1)
-        elif key == tcod.event.K_n:
-            action = BumpAction(*context, dx=1, dy=1)
-        elif key == tcod.event.K_PERIOD:
+        if key in MOVE_KEYS:
+            dx, dy = MOVE_KEYS[key]
+            action = BumpAction(*context, dx, dy)
+        elif key in WAIT_KEYS:
             action = WaitAction(*context)
 
         elif key == tcod.event.K_ESCAPE:


### PR DESCRIPTION
When some `if..elif` chains become too large they can be replaced by dictionaries.

This is the set of keys I commonly use when implementing diagonal movement.