### PR TITLE
Mark BaseAI/Fighter as Actor only components.

### DIFF
--- a/components/ai.py
+++ b/components/ai.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class BaseAI(Action, BaseComponent):
+    entity: Actor
+
     def perform(self) -> None:
         raise NotImplementedError()
 

--- a/components/fighter.py
+++ b/components/fighter.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from components.base_component import BaseComponent
-from entity import Actor
 from input_handlers import GameOverEventHandler
 from render_order import RenderOrder
 
+if TYPE_CHECKING:
+    from entity import Actor
+
 
 class Fighter(BaseComponent):
+    entity: Actor
+
     def __init__(self, hp: int, defense: int, power: int):
         self.max_hp = hp
         self._hp = hp
@@ -18,7 +26,7 @@ class Fighter(BaseComponent):
     @hp.setter
     def hp(self, value: int) -> None:
         self._hp = max(0, min(value, self.max_hp))
-        if self._hp == 0 and isinstance(self.entity, Actor) and self.entity.ai:
+        if self._hp == 0 and self.entity.ai:
             self.die()
 
     def die(self) -> None:


### PR DESCRIPTION
I'm surprised it worked this quickly, I thought it would be harder to do.

There's a small chance this actually is invalid, but for now MyPy will verify the types the way I want it to.

This also fixes a type error that BaseAI had after the change to BaseComponent.