### PR TITLE
Remove EscapeAction.

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -58,11 +58,6 @@ class PickupAction(Action):
         raise exceptions.Impossible("There is nothing here to pick up.")
 
 
-class EscapeAction(Action):
-    def perform(self) -> None:
-        raise SystemExit()
-
-
 class ItemAction(Action):
     def __init__(self, entity: Actor, item: Item):
         super().__init__(entity)

--- a/input_handlers.py
+++ b/input_handlers.py
@@ -8,7 +8,6 @@ import actions
 from actions import (
     Action,
     BumpAction,
-    EscapeAction,
     PickupAction,
     WaitAction,
 )
@@ -298,7 +297,7 @@ class MainGameEventHandler(EventHandler):
             action = WaitAction(player)
 
         elif key == tcod.event.K_ESCAPE:
-            action = EscapeAction(player)
+            raise SystemExit()
         elif key == tcod.event.K_v:
             self.engine.event_handler = HistoryViewer(self.engine)
 
@@ -317,27 +316,9 @@ class MainGameEventHandler(EventHandler):
 
 
 class GameOverEventHandler(EventHandler):
-    def handle_action(self, action: Optional[Action]) -> bool:
-        if action is None:
-            return False
-
-        try:
-            action.perform()
-        except exceptions.Impossible as exc:
-            self.engine.message_log.add_message(exc.args[0], color.impossible)
-
-        return False
-
-    def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
-        action: Optional[Action] = None
-
-        key = event.sym
-
-        if key == tcod.event.K_ESCAPE:
-            action = EscapeAction(self.engine.player)
-
-        # No valid key was pressed
-        return action
+    def ev_keydown(self, event: tcod.event.KeyDown) -> None:
+        if event.sym == tcod.event.K_ESCAPE:
+            raise SystemExit()
 
 
 CURSOR_Y_KEYS = {


### PR DESCRIPTION
Exiting the program should not be an entity action.  The assumption that it is was causing issues since dead actors are not supposed to perform additional actions after their death.

If you want to be extra careful then you could add this to `GameOverEventHandler`:
```python
def handle_action(self, action: Optional[Action]) -> bool:
    """Ensure this handler does not perform any actions."""
    assert action is None, action
    return super().handle_action(None)
```