### PR TITLE
Replace deprecated call to tcod.context.new_terminal.

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,9 +18,9 @@ def main() -> None:
 
     event_handler = EventHandler()
 
-    with tcod.context.new_terminal(
-        screen_width,
-        screen_height,
+    with tcod.context.new(
+        columns=screen_width,
+        rows=screen_height,
         tileset=tileset,
         title="Yet Another Roguelike Tutorial",
         vsync=True,


### PR DESCRIPTION
Python-tcod 11.16 switched to using a single function instead of the `new_terminal` and `new_window` functions.

This is a very minor change, and is probably not worth merging on its own.

What would be the correct way to update the tutorial?  Would it be to merge the PR's here, propagate them along the later part branches, and then make a PR to update the site?