### PR TITLE
Proposed fix for AOE preview

### DIFF
--- a/components/consumable.py
+++ b/components/consumable.py
@@ -91,17 +91,19 @@ class FireballDamageConsumable(Consumable):
         target_xy = action.target_xy
 
         if not self.engine.game_map.visible[target_xy]:
+            self.engine.clear_aoe()
             raise Impossible("You cannot target an area that you cannot see.")
 
         targets_hit = False
         for actor in self.engine.game_map.actors:
-            if actor.distance(*target_xy) <= self.radius:
+            if self.engine.game_map.aoe[actor.x, actor.y] == True:
                 self.engine.message_log.add_message(
                     f"The {actor.name} is engulfed in a fiery explosion, taking {self.damage} damage!"
                 )
                 actor.fighter.take_damage(self.damage)
                 targets_hit = True
 
+        self.engine.clear_aoe()
         if not targets_hit:
             raise Impossible("There are no targets in the radius.")
         self.consume()

--- a/game_map.py
+++ b/game_map.py
@@ -28,6 +28,9 @@ class GameMap:
         self.explored = np.full(
             (width, height), fill_value=False, order="F"
         )  # Tiles the player has seen before
+        self.aoe = np.full(
+            (width, height), fill_value=False, order="F"
+        )  # Tiles in the aoe for an action
 
     @property
     def gamemap(self) -> GameMap:
@@ -79,8 +82,10 @@ class GameMap:
         Otherwise, the default is "SHROUD".
         """
         console.tiles_rgb[0 : self.width, 0 : self.height] = np.select(
-            condlist=[self.visible, self.explored],
-            choicelist=[self.tiles["light"], self.tiles["dark"]],
+            #condlist=[self.visible, self.explored],
+            condlist=[self.aoe, self.visible, self.explored],
+            #choicelist=[self.tiles["light"], self.tiles["dark"]],
+            choicelist=[self.tiles["aoe"], self.tiles["light"], self.tiles["dark"]],
             default=tile_types.SHROUD,
         )
 

--- a/input_handlers.py
+++ b/input_handlers.py
@@ -92,7 +92,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
             self.engine.mouse_location = event.tile.x, event.tile.y
 
     def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
-        raise SystemExit()
+        raise SystemExit(0)
 
     def on_render(self, console: tcod.Console) -> None:
         self.engine.render(console)
@@ -260,6 +260,7 @@ class SelectIndexHandler(AskUserEventHandler):
             return None
         elif key in CONFIRM_KEYS:
             return self.on_index_selected(*self.engine.mouse_location)
+        self.engine.clear_aoe()
         return super().ev_keydown(event)
 
     def ev_mousebuttondown(self, event: tcod.event.MouseButtonDown) -> Optional[Action]:
@@ -314,17 +315,11 @@ class AreaRangedAttackHandler(SelectIndexHandler):
         """Highlight the tile under the cursor."""
         super().on_render(console)
 
-        x, y = self.engine.mouse_location
+        # Compute the aoe for the cursor location.
+        self.engine.update_aoe(location=self.engine.mouse_location, radius=self.radius)
 
-        # Draw a rectangle around the targeted area, so the player can see the affected tiles.
-        console.draw_frame(
-            x=x - self.radius - 1,
-            y=y - self.radius - 1,
-            width=self.radius ** 2,
-            height=self.radius ** 2,
-            fg=color.red,
-            clear=False,
-        )
+    def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
+        return super().ev_keydown(event)
 
     def on_index_selected(self, x: int, y: int) -> Optional[Action]:
         return self.callback((x, y))
@@ -345,7 +340,7 @@ class MainGameEventHandler(EventHandler):
             action = WaitAction(player)
 
         elif key == tcod.event.K_ESCAPE:
-            raise SystemExit()
+            raise SystemExit(0)
         elif key == tcod.event.K_v:
             self.engine.event_handler = HistoryViewer(self.engine)
 
@@ -366,7 +361,7 @@ class MainGameEventHandler(EventHandler):
 class GameOverEventHandler(EventHandler):
     def ev_keydown(self, event: tcod.event.KeyDown) -> None:
         if event.sym == tcod.event.K_ESCAPE:
-            raise SystemExit()
+            raise SystemExit(0)
 
 
 CURSOR_Y_KEYS = {

--- a/tile_types.py
+++ b/tile_types.py
@@ -18,6 +18,7 @@ tile_dt = np.dtype(
         ("transparent", np.bool),  # True if this tile doesn't block FOV.
         ("dark", graphic_dt),  # Graphics for when this tile is not in FOV.
         ("light", graphic_dt),  # Graphics for when the tile is in FOV.
+        ("aoe", graphic_dt), # Graphics for when the tile is in the aoe blast.
     ]
 )
 
@@ -28,9 +29,10 @@ def new_tile(
     transparent: int,
     dark: Tuple[int, Tuple[int, int, int], Tuple[int, int, int]],
     light: Tuple[int, Tuple[int, int, int], Tuple[int, int, int]],
+    aoe: Tuple[int, Tuple[int, int, int], Tuple[int, int, int]],
 ) -> np.ndarray:
     """Helper function for defining individual tile types """
-    return np.array((walkable, transparent, dark, light), dtype=tile_dt)
+    return np.array((walkable, transparent, dark, light, aoe), dtype=tile_dt)
 
 
 # SHROUD represents unexplored, unseen tiles
@@ -41,10 +43,12 @@ floor = new_tile(
     transparent=True,
     dark=(ord(" "), (255, 255, 255), (50, 50, 150)),
     light=(ord(" "), (255, 255, 255), (200, 180, 50)),
+    aoe=(ord(" "), (255, 255, 255), (250, 120, 120)),
 )
 wall = new_tile(
     walkable=False,
     transparent=False,
     dark=(ord(" "), (255, 255, 255), (0, 0, 100)),
     light=(ord(" "), (255, 255, 255), (130, 110, 50)),
+    aoe=(ord(" "), (255, 255, 255), (180, 50, 50)),
 )


### PR DESCRIPTION
Here is proposed fix for the inaccurate aoe blast preview for tutorial 9.  
Currently the tutorial previews an aoe damage type using a rectangular outline where the code calculates a hit based on the distance from the center of the blast.  This results in the corners of the preview not getting hit.  A more accurate preview would have been a circle.

Looking into libtcod, there is no function to draw a circle on the console (at least I could not find one).  However, there is a nice function to compute the field of view from a perspective.  This works out nicely since the blast is basically the fov from the center of the blast.  A nice side effect is that we can also take the walls into account and they can actually provide cover from the blast.

Here is what it looks like:
![AOE_Preview](https://user-images.githubusercontent.com/63171460/124027280-87709400-d9a7-11eb-8a0e-c7128eae0a1c.png)

For the implementation, I just added another graphic to the tile data type named aoe.  I initially was going to just adjust the alpha on the console for affected tiles, but doing it this was gives the flexibility to use a different character and coloring for the different tiles.

```
# Tile struct used for statically defined tile data.
tile_dt = np.dtype(
    [
        ...
        ("light", graphic_dt),  # Graphics for when the tile is in FOV.
        ("aoe", graphic_dt), # Graphics for when the tile is in the aoe blast.
    ]
)
```
 
In game_map, I just create another array similar to visible and explorer to hold the aoe preview.

In engine, I just added the functionality for calculate the aoe preview and to clear it.  The update_aoe() function initially just calculates a fov from the center of the blast.  This is basically the same as calculating the player fov.  The second part checks that any tiles that are part of the aoe are also visible.  It this isn't done, you can use this to see shrouded parts of the map.  I am a bit of a python noob, there might also be a better way to update the aoe array.
```
    def update_aoe(
        self, location: Tuple[int, int], radius: int, include_walls: bool = False,
    ) -> None:
        """Compute the blast area for an aoe action."""

        # Start with the fov from the center of the blast.
        self.game_map.aoe[:] = compute_fov(
            self.game_map.tiles["transparent"],
            location,
            radius=radius,
            light_walls=include_walls,
            algorithm=tcod.FOV_BASIC,
        )

        # Now limit the preview to visible tiles.
        it = np.nditer(
            [self.game_map.aoe, self.game_map.visible, None], flags=['buffered']
        )

        with it:
            for has_aoe, is_visible, tmp in it:
                tmp[...] = has_aoe and is_visible
            self.game_map.aoe = it.operands[2]

```

I changed consumable to use the aoe preview to determine if an entity is getting hit from the blast and to clear out the aoe preview on use.  Now the preview is 1:1 with the hit calculation.

The rest of the changes are just adding in the new functionality.
