### PR TITLE
Fix extra staircase generation

### DIFF
--- a/game/procgen.py
+++ b/game/procgen.py
@@ -177,10 +177,10 @@ def generate_dungeon(
 
         place_entities(new_room, dungeon, engine.game_world.current_floor)
 
-        dungeon.tiles[center_of_last_room] = game.tiles.down_stairs
-        dungeon.downstairs_location = center_of_last_room
-
         # Finally, append the new room to the list.
         rooms.append(new_room)
+
+    dungeon.tiles[center_of_last_room] = game.tiles.down_stairs
+    dungeon.downstairs_location = center_of_last_room
 
     return dungeon


### PR DESCRIPTION
On every level, a staircase tile is generated at `(0, 0)`. This can be seen by temporarily disabling collision checks from Move actions, but can also be encountered normally if a room is generated too close to the top left corner (which allows the player to go out of bounds even without disabling collision checks).
![extra-staircase](https://user-images.githubusercontent.com/32916123/184258789-f25dab70-59ac-4018-bc2f-a9b5d9a014d4.png)
This is because the current code places a staircase tile at the center of every room generated, and the `center_of_last_room` variable in `procgen.py` is initialized to `(0, 0)`. 
This means that extra staircase tiles are technically also generated in the centers of all rooms, but are overwritten by ground tiles when tunnels are placed between rooms. Disabling tunnel generation lets us see this:
![room-staircases](https://user-images.githubusercontent.com/32916123/184259127-0c5f39d4-abef-4fa8-a368-a937dc017bed.png)
While this isn't a problem now, it could become a problem if tunnel generation is changed in the future (if, for example, tunnels were changed to not always generate from the center of rooms for variety).

Both problems are fixed by moving the staircase placement outside of the for loop which places rooms, which I believe is the intended behavior.

Apologies if I have done anything wrong with this pull request! This is my first one and I'm not sure if I'm requesting to pull to the correct branch. 😅

Thanks for the tutorial! This was a great resource to follow and was just what I was looking for to learn more about roguelike development.