### PR TITLE
Update input_handlers.py

### DIFF
--- a/input_handlers.py
+++ b/input_handlers.py
@@ -14,16 +14,16 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 
         key = event.sym
 
-        if key == tcod.event.K_UP:
+        if key == tcod.event.KeySym.UP:
             action = MovementAction(dx=0, dy=-1)
-        elif key == tcod.event.K_DOWN:
+        elif key == tcod.event.KeySym.DOWN:
             action = MovementAction(dx=0, dy=1)
-        elif key == tcod.event.K_LEFT:
+        elif key == tcod.event.KeySym.LEFT:
             action = MovementAction(dx=-1, dy=0)
-        elif key == tcod.event.K_RIGHT:
+        elif key == tcod.event.KeySym.RIGHT:
             action = MovementAction(dx=1, dy=0)
 
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction()
 
         # No valid key was pressed


### PR DESCRIPTION
In v12.3, [SDL2 changed Key constants to enums](https://python-tcod.readthedocs.io/en/latest/tcod/event.html#keyboard-enums) e.g. `tcod.event.K_UP` should be replaced with `tcod.event.KeySym.UP`

Seems like it's not a problem yet, but errors popping up can be frightening:

`FutureWarning: Key constants have been replaced with enums.
'tcod.event.K_UP' should be replaced with 'tcod.event.KeySym.UP'`

I changed all the branches, but that seems like a lot of PRs - pls lmk the best way to do that, i'm still a git noob.